### PR TITLE
Add enum pseudo-type definition

### DIFF
--- a/pkg/godef/enum.go
+++ b/pkg/godef/enum.go
@@ -1,0 +1,15 @@
+package godef
+
+import "github.com/kaloseia/clone"
+
+type Enum struct {
+	Type    GoTypeDerived
+	Entries []EnumEntry
+}
+
+func (s Enum) DeepClone() Enum {
+	return Enum{
+		Type:    s.Type.DeepClone(),
+		Entries: clone.DeepCloneSlice(s.Entries),
+	}
+}

--- a/pkg/godef/enum_entry.go
+++ b/pkg/godef/enum_entry.go
@@ -1,0 +1,13 @@
+package godef
+
+type EnumEntry struct {
+	Name  string
+	Value any
+}
+
+func (e EnumEntry) DeepClone() EnumEntry {
+	return EnumEntry{
+		Name:  e.Name,
+		Value: e.Value,
+	}
+}


### PR DESCRIPTION
Although enums are modelled in Go as a set of defined constants, we introduce a utility structure for storing enum data that renders as follows:

```go
type MyEnum string // `string` is a derived native type

const (
  MyEnumHello MyEnum = "hello"
  MyEnumWorld MyEnum = "world"
)
```
